### PR TITLE
USERNAMEをTRELLONAMEに変更 #1

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,4 +1,4 @@
 export KEY=
 export TOKEN=
-export USERNAME=
+export TRELLONAME=
 export LANE_ID=

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ https://trello.com/1/authorize?key=<上で取得したKey>&name=&expiration=neve
 
 export KEY=
 export TOKEN=
-export USERNAME=
+export TRELLONAME=
 
 ```
 
@@ -80,7 +80,7 @@ Finish.
 
 export KEY=
 export TOKEN=
-export USERNAME=
+export TRELLONAME=
 # 追加
 export LANE_ID=
 
@@ -110,4 +110,3 @@ posted: 06月14日 (金)
 
 ボート内レーンを出力し直接キー操作で選択。
 POSTしたい内容を入れると送信できる機能をリリース予定です。
-

--- a/lib/board_id.rb
+++ b/lib/board_id.rb
@@ -30,25 +30,25 @@ class BoardId
       missing_env = []
       missing_env.push('KEY') if ENV['KEY'].nil?
       missing_env.push('TOKEN') if ENV['TOKEN'].nil?
-      missing_env.push('USERNAME') if ENV['USERNAME'].nil?
+      missing_env.push('TRELLONAME') if ENV['TRELLONAME'].nil?
 
       missing_env
     end
   end
 
-  attr_reader :end_point, :target, :key, :token, :username, :client
+  attr_reader :end_point, :target, :key, :token, :trelloname, :client
 
   def initialize
     @end_point = 'https://trello.com/1'
     @target    = 'members'
     @key       = ENV['KEY']
     @token     = ENV['TOKEN']
-    @username  = ENV['USERNAME']
+    @trelloname  = ENV['TRELLONAME']
     @client    = Request.build
   end
 
   def get
-    url         = "#{end_point}/#{target}/#{username}/boards?key=#{key}&token=#{token}&fields=name"
+    url         = "#{end_point}/#{target}/#{trelloname}/boards?key=#{key}&token=#{token}&fields=name"
     response    = client.get(url: url)
 
     parse_body(body: response.body)


### PR DESCRIPTION
## Fix

https://github.com/tunagohan/trello_add_week/issues/1

## Problem

When Zsh was used, USERNAME could not be set as an environment variable.
Therefore, USERNAME was changed to an environment variable called TRELLONAME.

Thanks @t0yohei